### PR TITLE
Prepare for release v0.7.0-beta.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	kmodules.xyz/monitoring-agent-api v0.0.0-20200828051750-42aa8e7852f3
 	kmodules.xyz/offshoot-api v0.0.0-20200521035628-e135bf07b226
 	kmodules.xyz/webhook-runtime v0.0.0-20200522123600-ca70a7e28ed0
-	kubedb.dev/apimachinery v0.14.0-beta.1.0.20200903071357-152cef57748c
+	kubedb.dev/apimachinery v0.14.0-beta.2
 )
 
 replace google.golang.org/api => google.golang.org/api v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -1255,8 +1255,8 @@ kmodules.xyz/prober v0.0.0-20200521101241-adf06150535c h1:aV6O9NbDpnFVra/D8c7b7T
 kmodules.xyz/prober v0.0.0-20200521101241-adf06150535c/go.mod h1:XYWZkfQquD09Mn+O7piHS+SEPq9oFV1Wy2WZ9DA+oeA=
 kmodules.xyz/webhook-runtime v0.0.0-20200522123600-ca70a7e28ed0 h1:rEOWPdiRYShJdJxX0sf76JYWOMzPQH4v8ByT+DRCmVY=
 kmodules.xyz/webhook-runtime v0.0.0-20200522123600-ca70a7e28ed0/go.mod h1:9hUftUcjvzDSiO5LIbe2U8Naz4tyS9Ndf1LRzsytMzs=
-kubedb.dev/apimachinery v0.14.0-beta.1.0.20200903071357-152cef57748c h1:W70cG2PFsrx3iURRdGqckpCbZ309slkAOoLO1JpLkjA=
-kubedb.dev/apimachinery v0.14.0-beta.1.0.20200903071357-152cef57748c/go.mod h1:WQ/oXfTfXNRfz6JvRBIoHwi3Dg4eumKnXu5WXquGF0Y=
+kubedb.dev/apimachinery v0.14.0-beta.2 h1:Ws+DYzQmESOP7mwaaeXcDjWae9joiG/Xi8yYoSBnLD0=
+kubedb.dev/apimachinery v0.14.0-beta.2/go.mod h1:WQ/oXfTfXNRfz6JvRBIoHwi3Dg4eumKnXu5WXquGF0Y=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha1/constants.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha1/constants.go
@@ -88,11 +88,9 @@ const (
 	LabelProxySQLName        = ProxySQLKey + "/name"
 	LabelProxySQLLoadBalance = ProxySQLKey + "/load-balance"
 
-	ProxySQLUserKey               = "proxysqluser"
-	ProxySQLPasswordKey           = "proxysqlpass"
 	ProxySQLMySQLNodePort         = 6033
 	ProxySQLAdminPort             = 6032
-	ProxySQLAdminPortName         = "proxyadm"
+	ProxySQLAdminPortName         = "admin"
 	ProxySQLDataMountPath         = "/var/lib/proxysql"
 	ProxySQLCustomConfigMountPath = "/etc/custom-config"
 

--- a/vendor/kubedb.dev/apimachinery/pkg/controller/controller.go
+++ b/vendor/kubedb.dev/apimachinery/pkg/controller/controller.go
@@ -24,7 +24,6 @@ import (
 	kubedbinformers "kubedb.dev/apimachinery/client/informers/externalversions"
 
 	"github.com/appscode/go/log/golog"
-	cm "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	cmInformers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions"
 	crd_cs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	externalInformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
@@ -58,8 +57,6 @@ type Controller struct {
 	AppCatalogClient appcat_cs.Interface
 	// StashClient for stash
 	StashClient scs.Interface
-	//CertManagerClient for cert-manger
-	CertManagerClient cm.Interface
 	// Cluster topology when the operator started
 	ClusterTopology *core_util.Topology
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1071,7 +1071,7 @@ kmodules.xyz/prober/api/v1
 # kmodules.xyz/webhook-runtime v0.0.0-20200522123600-ca70a7e28ed0
 kmodules.xyz/webhook-runtime/admission/v1beta1
 kmodules.xyz/webhook-runtime/registry/admissionreview/v1beta1
-# kubedb.dev/apimachinery v0.14.0-beta.1.0.20200903071357-152cef57748c
+# kubedb.dev/apimachinery v0.14.0-beta.2
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling
 kubedb.dev/apimachinery/apis/autoscaling/v1alpha1


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.09.04-beta.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/4
Signed-off-by: 1gtm <1gtm@appscode.com>